### PR TITLE
Issue #158 : By default hide the custom field columns(record id + hashed columns) in reports

### DIFF
--- a/tjreports/plugins/actionlog/tjreports/tjreports.xml
+++ b/tjreports/plugins/actionlog/tjreports/tjreports.xml
@@ -2,12 +2,12 @@
 <extension version="3.9" type="plugin" group="actionlog" method="upgrade">
 	<name>plg_actionlog_tjreports</name>
 	<author>Techjoomla</author>
-	<creationDate>22nd Oct 2019</creationDate>
+	<creationDate>24th Oct 2019</creationDate>
 	<copyright>Copyright (C) 2016 - 2019 Techjoomla. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
 	<authorEmail>extensions@techjoomla.com</authorEmail>
 	<authorUrl>https://techjoomla.com</authorUrl>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 	<description>PLG_ACTIONLOG_TJREPORTS_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="tjreports">tjreports.php</filename>

--- a/tjreports/plugins/content/tjreportsfields/tjreportsfields.xml
+++ b/tjreports/plugins/content/tjreportsfields/tjreportsfields.xml
@@ -5,10 +5,10 @@
 	<author>Techjoomla</author>
 	<authorEmail>extensions@techjoomla.com</authorEmail>
 	<authorUrl>https://techjoomla.com</authorUrl>
-	<creationDate>22nd Oct 2019</creationDate>
+	<creationDate>24th Oct 2019</creationDate>
 	<copyright>Copyright (C) 2016 - 2019 Techjoomla. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 
 	<files>
 		<filename plugin="tjreportsfields">tjreportsfields.php</filename>

--- a/tjreports/plugins/privacy/tjreports/tjreports.xml
+++ b/tjreports/plugins/privacy/tjreports/tjreports.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.4" type="plugin" group="privacy" method="upgrade">
 	<name>plg_privacy_tjreports</name>
-	<version>1.1.2</version>
-	<creationDate>22nd Oct 2019</creationDate>
+	<version>1.1.3</version>
+	<creationDate>24th Oct 2019</creationDate>
 	<author>Techjoomla</author>
 	<authorEmail>extensions@techjoomla.com</authorEmail>
 	<authorUrl>https://techjoomla.com</authorUrl>

--- a/tjreports/plugins/user/tjreportsindexer/tjreportsindexer.xml
+++ b/tjreports/plugins/user/tjreportsindexer/tjreportsindexer.xml
@@ -5,10 +5,10 @@
 	<author>Techjoomla</author>
 	<authorEmail>extensions@techjoomla.com</authorEmail>
 	<authorUrl>https://techjoomla.com</authorUrl>
-	<creationDate>22nd Oct 2019</creationDate>
+	<creationDate>24th Oct 2019</creationDate>
 	<copyright>Copyright (C) 2016 - 2019 Techjoomla. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
-	<version>1.1.2</version>
+	<version>1.1.3</version>
 	<install>
         <sql>
             <file driver="mysql" charset="utf8">sql/tjreportsindexer.install.sql</file>

--- a/tjreports/site/models/reports.php
+++ b/tjreports/site/models/reports.php
@@ -177,9 +177,8 @@ class TjreportsModelReports extends JModelList
 		{
 			$customField = array (
 				'title'              => ($columnLabels[$columnName]) ? $columnLabels[$columnName] : $columnName,
-				'table_column'       => $this->customFieldsTableAlias . '.' . $columnName
-
-				// , 'disable_sorting' => true
+				'table_column'       => $this->customFieldsTableAlias . '.' . $columnName,
+				'not_show_hide'      => false
 			);
 
 			// Eg. tuf.dob

--- a/tjreports/tjreports.xml
+++ b/tjreports/tjreports.xml
@@ -6,8 +6,8 @@
 	<authorUrl>https://techjoomla.com</authorUrl>
 	<copyright>Copyright (C) 2016 - 2019 Techjoomla. All rights reserved.</copyright>
 	<license>http://www.gnu.org/licenses/gpl-2.0.html GNU/GPL</license>
-	<creationDate>22nd Oct 2019</creationDate>
-	<version>1.1.2</version>
+	<creationDate>24th Oct 2019</creationDate>
+	<version>1.1.3</version>
 	<description>This component is used to access all the report at single place.</description>
 	<install>
 		<!-- Runs on install -->


### PR DESCRIPTION
By default hide the custom field columns(record id + hashed columns) in reports but show them in "Hide / Show Columns" dropdown so that admin can set as per the requirement.

Please check the below link for more details.

https://tracker.tekdi.net/issues/152327