### PR TITLE
Issue #164 fix: After unchecking the column from 'Hide or Show Columns' drop down option, unchecked column gets removed from dropdown

### DIFF
--- a/tjreports/site/models/reports.php
+++ b/tjreports/site/models/reports.php
@@ -1171,6 +1171,7 @@ class TjreportsModelReports extends JModelList
 			}
 		}
 
+		// Used to get the columns which are hide by default in load params
 		if (!empty($this->filterDefaultColToHide))
 		{
 			$this->defaultColToHide = $this->filterDefaultColToHide;
@@ -1250,6 +1251,7 @@ class TjreportsModelReports extends JModelList
 					}
 					else
 					{
+						// Used to get the columns which are hide (false) by default in load params
 						$this->filterDefaultColToHide[$cols] = $cols;
 					}
 
@@ -1265,7 +1267,10 @@ class TjreportsModelReports extends JModelList
 			// Check PII permission
 			if (!empty($param['piiColumns']) && !$this->piiPermission)
 			{
+				/* Checked the columns which are hide(false) in load params & if set them as piiColumns
+				* then it only returns the columns which are not available in piiColumns. */
 				$this->filterDefaultColToHide = array_diff($this->filterDefaultColToHide, $param['piiColumns']);
+
 				$this->filterParamColToshow = array_diff($this->filterParamColToshow, $param['piiColumns']);
 				$this->filterShowhideCols = array_diff($this->filterShowhideCols, $param['piiColumns']);
 			}

--- a/tjreports/site/models/reports.php
+++ b/tjreports/site/models/reports.php
@@ -48,7 +48,7 @@ class TjreportsModelReports extends JModelList
 	public $showhideCols = array();
 
 	// Columns which will be displayed by default
-	private $defaultColToShow = array();
+	public $defaultColToShow = array();
 
 	// Columns which will be hide by default
 	private $defaultColToHide = array();
@@ -85,7 +85,10 @@ class TjreportsModelReports extends JModelList
 
 	private $filterPiiColumns = array();
 
-	private $filterParamColToshow = array();
+	public $filterParamColToshow = array();
+
+	// Used to get the columns which are hide by default in load params
+	public $filterDefaultColToHide = array();
 
 	/**
 	 * Constructor.
@@ -1140,7 +1143,7 @@ class TjreportsModelReports extends JModelList
 		}
 
 		$query = $this->_db->getQuery(true);
-		$this->filterShowhideCols = $this->filterPiiColumns = $this->filterParamColToshow = array();
+		$this->filterDefaultColToHide = $this->filterShowhideCols = $this->filterPiiColumns = $this->filterParamColToshow = array();
 
 		// $this->filterSelColToshow = $selColToshow;
 
@@ -1166,6 +1169,11 @@ class TjreportsModelReports extends JModelList
 			{
 				$selColToshow = $this->filterParamColToshow;
 			}
+		}
+
+		if (!empty($this->filterDefaultColToHide))
+		{
+			$this->defaultColToHide = $this->filterDefaultColToHide;
 		}
 
 		if (!empty($this->filterShowhideCols))
@@ -1240,6 +1248,10 @@ class TjreportsModelReports extends JModelList
 					{
 						$this->filterParamColToshow[$cols] = $cols;
 					}
+					else
+					{
+						$this->filterDefaultColToHide[$cols] = $cols;
+					}
 
 					if (!empty($param['showHideColumns']) && !in_array($cols, $param['showHideColumns']) && !empty($selColToshow))
 					{
@@ -1253,6 +1265,7 @@ class TjreportsModelReports extends JModelList
 			// Check PII permission
 			if (!empty($param['piiColumns']) && !$this->piiPermission)
 			{
+				$this->filterDefaultColToHide = array_diff($this->filterDefaultColToHide, $param['piiColumns']);
 				$this->filterParamColToshow = array_diff($this->filterParamColToshow, $param['piiColumns']);
 				$this->filterShowhideCols = array_diff($this->filterShowhideCols, $param['piiColumns']);
 			}

--- a/tjreports/site/views/reports/view.base.php
+++ b/tjreports/site/views/reports/view.base.php
@@ -169,17 +169,26 @@ class ReportsViewBase extends JViewLegacy
 		 */
 		$this->showHideColumns = $this->model->showhideCols;
 
+		/* To get the columns from loadparams*/
+		$this->defaultColToshow = $this->model->filterParamColToshow;
+
+		/* Check the columns in loadparams are available or not & show plugin level columns & custom field columns
+		 * in case if load params are not available*/
+		if (empty($this->defaultColToshow))
+		{
+			$this->defaultColToshow = $this->model->defaultColToShow;
+		}
+
 		if (!empty($this->defaultColToHide))
 		{
-			$this->showHideColumns = array_intersect($this->model->showhideCols, array_merge($this->model->getState('colToshow'), $this->defaultColToHide));
+			$this->showHideColumns = array_intersect($this->model->showhideCols, array_merge($this->defaultColToshow, $this->defaultColToHide));
 		}
 
 		$this->sortable        = $this->model->sortableColumns;
 		$this->emailColumn     = $this->model->getState('emailColumn');
 		$this->srButton        = $this->model->showSearchResetButton;
 
-		// Array_intersect - if column present in colToshow as true/false but not in showHideColumns then remove it
-		$this->colToshow       = array_intersect($this->model->getState('colToshow'), $this->model->showhideCols);
+		$this->colToshow       = $this->model->getState('colToshow');
 
 		$this->filterValues    = $this->model->getState('filters');
 


### PR DESCRIPTION
After unchecking the column from the "Hide / Show Columns" drop-down option, the unchecked column gets removed from dropdown & does not display this option to show that column in a report.