### PR TITLE
Issue #169 fix: Displays custom fields data twice in TJ Reports API

### DIFF
--- a/tjreports/site/models/reports.php
+++ b/tjreports/site/models/reports.php
@@ -729,7 +729,6 @@ class TjreportsModelReports extends JModelList
 			{
 				$customFieldColumns[] = $this->customFieldsTableAlias . '.record_id';
 
-				$query->select($db->quoteName($customFieldColumns));
 				$query->join(
 					'LEFT', $db->quoteName($this->customFieldsTable, $this->customFieldsTableAlias) .
 					' ON ' . $db->quoteName($this->customFieldsTableAlias . '.record_id') . ' = ' . $db->quoteName($this->customFieldsQueryJoinOn)


### PR DESCRIPTION
TJ Reports fetches custom fields data twice in the report & it shows data twice the in TJ Reports API.