### PR TITLE
Bug #169215 fix: Reports > Reports having dynamic column shows different data with / without loading params

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,3 +12,4 @@
 - #169471 Reports > In report data not showing count with link, it's showing href string
 - #169429 Reports > Frontend > Reports > Radio button and Export CSV alignment messed up
 - #169428 Reports > Frontend > Reports > Language constant missing
+- #169215 Reports > Reports having dynamic column shows different data with / without loading params

--- a/tjreports/administrator/models/tjreport.php
+++ b/tjreports/administrator/models/tjreport.php
@@ -191,6 +191,14 @@ class TjreportsModelTjreport extends JModelAdmin
 			 * so false value column not display on report by default.*/
 			if (!empty($defaultColToHide))
 			{
+				foreach ($defaultColToHide as $key => $colHide)
+				{
+					if (strpos($key, '::') !== false)
+					{
+						unset($defaultColToHide[$key]);
+					}
+				}
+
 				$params['colToshow']        = array_merge($params['colToshow'], $defaultColToHide);
 			}
 

--- a/tjreports/administrator/models/tjreport.php
+++ b/tjreports/administrator/models/tjreport.php
@@ -191,6 +191,7 @@ class TjreportsModelTjreport extends JModelAdmin
 			 * so false value column not display on report by default.*/
 			if (!empty($defaultColToHide))
 			{
+				// Here remove dynamic column(for example: lesson::lesson_status) from defaultColToHide because no need to load dynamic column.
 				foreach ($defaultColToHide as $key => $colHide)
 				{
 					if (strpos($key, '::') !== false)


### PR DESCRIPTION
…hout loading params and also some language constants are missing after loading params in report.