### PR TITLE
Bug #170012 fix: Front end >> reports >> campaigns promoter report >>displaying count 0 error

### DIFF
--- a/tjreports/site/views/reports/tmpl/default.php
+++ b/tjreports/site/views/reports/tmpl/default.php
@@ -40,7 +40,7 @@ foreach ($this->colToshow as $key => $data)
 }
 
 $input                = Factory::getApplication()->input;
-$displayFilters       = $this->userFilters;
+$displayFilters       = (array) $this->userFilters;
 $totalHeadRows        = count($displayFilters);
 $reportId             = $app->getUserStateFromRequest('reportId', 'reportId', '');
 $user                 = Factory::getUser();


### PR DESCRIPTION
Fatal error: 
0 count(): Argument #1 ($var) must be of type Countable|array, null given
/var/www/ttpllt-php8.local/public/jgivephp8/components/com_tjreports/views/reports/tmpl/default.php:44